### PR TITLE
Feat dungeon system

### DIFF
--- a/Fantasy-Grower/Assets/Scripts/Dungeon.meta
+++ b/Fantasy-Grower/Assets/Scripts/Dungeon.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 54f89240703479c4aac198efdadf69c3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Fantasy-Grower/Assets/Scripts/Dungeon/SO_DungeonState.cs
+++ b/Fantasy-Grower/Assets/Scripts/Dungeon/SO_DungeonState.cs
@@ -1,0 +1,36 @@
+using System;
+using UnityEngine;
+
+public enum DungeonState
+{
+    None,
+    Start,
+    InProgress,
+    Failed,
+    Completed,
+}
+
+public class SO_DungeonState : ScriptableObject
+{
+    private DungeonState currentState;
+
+    /// <summary>
+    /// 상태 변경 시 이벤트를 발생시키는 프로퍼티
+    /// </summary>
+    public DungeonState DungeonState
+    {
+        get => currentState;
+        set
+        {
+            if (currentState == value)
+                return;
+            currentState = value;
+            OnDungeonStateChanged?.Invoke(currentState);
+        }
+    }
+
+    /// <summary>
+    /// 사용 예 : state.OnDungeonStateChanged += (newState) => { Debug.Log($"Dungeon state changed to: {newState}"); };
+    /// </summary>
+    public event Action<DungeonState> OnDungeonStateChanged;
+}

--- a/Fantasy-Grower/Assets/Scripts/Dungeon/SO_DungeonState.cs
+++ b/Fantasy-Grower/Assets/Scripts/Dungeon/SO_DungeonState.cs
@@ -34,4 +34,9 @@ public class SO_DungeonState : ScriptableObject
     /// 사용 예 : state.OnDungeonStateChanged += (newState) => { Debug.Log($"Dungeon state changed to: {newState}"); };
     /// </summary>
     public event Action<DungeonState> OnDungeonStateChanged;
+
+    private void OnEnable()
+    {
+        currentState = DungeonState.None; // 초기 상태 설정
+    }
 }

--- a/Fantasy-Grower/Assets/Scripts/Dungeon/SO_DungeonState.cs
+++ b/Fantasy-Grower/Assets/Scripts/Dungeon/SO_DungeonState.cs
@@ -3,11 +3,11 @@ using UnityEngine;
 
 public enum DungeonState
 {
-    None,
-    Start,
-    InProgress,
-    Failed,
-    Completed,
+    None, // 초기 상태, 던전이 시작되지 않은 상태
+    Start, // 던전이 시작된 상태
+    InProgress, // 던전이 진행 중인 상태
+    Failed, // 클리어에 실패한 상태
+    Completed, // 클리어에 성공한 상태
 }
 
 public class SO_DungeonState : ScriptableObject

--- a/Fantasy-Grower/Assets/Scripts/Dungeon/SO_DungeonState.cs
+++ b/Fantasy-Grower/Assets/Scripts/Dungeon/SO_DungeonState.cs
@@ -18,7 +18,7 @@ public class SO_DungeonState : ScriptableObject
     /// <summary>
     /// 상태 변경 시 이벤트를 발생시키는 프로퍼티
     /// </summary>
-    public DungeonState CurrentState;
+    public DungeonState CurrentState
     {
         get => currentState;
         set

--- a/Fantasy-Grower/Assets/Scripts/Dungeon/SO_DungeonState.cs
+++ b/Fantasy-Grower/Assets/Scripts/Dungeon/SO_DungeonState.cs
@@ -10,6 +10,7 @@ public enum DungeonState
     Completed, // 클리어에 성공한 상태
 }
 
+[CreateAssetMenu(fileName = "DungeonState", menuName = "ScriptableObjects/DungeonState", order = 1)]
 public class SO_DungeonState : ScriptableObject
 {
     private DungeonState currentState;
@@ -17,7 +18,7 @@ public class SO_DungeonState : ScriptableObject
     /// <summary>
     /// 상태 변경 시 이벤트를 발생시키는 프로퍼티
     /// </summary>
-    public DungeonState DungeonState
+    public DungeonState CurrentState;
     {
         get => currentState;
         set

--- a/Fantasy-Grower/Assets/Scripts/Dungeon/SO_DungeonState.cs.meta
+++ b/Fantasy-Grower/Assets/Scripts/Dungeon/SO_DungeonState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f519d2f876e2d2544aa07bf492a39730


### PR DESCRIPTION
Close #13 

## 개요
전투 시스템과 겹치지 않는 선에서의 던전 시스템을 제작합니다. (던전의 상태 관리 프로그램)

## TO-DO
- [x] Scripts/Dungeon/SO_DungeonState.cs 생성
- [x] DungeonState타입 생성(enum)
- [x] State가 바뀔 때 실행되는 이벤트를 생성합니다.

## 기타 사항
이 기능은 던전의 상태를 관리하며, 상태가 바뀔 때의 이벤트를 정의합니다.